### PR TITLE
Passing an ophyd-async device to find() or findall() now returns the …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ophyd-registry"
-version = "1.3.1"
+version = "1.3.2"
 authors = [
   { name="Mark Wolfman", email="wolfman@anl.gov" },
 ]

--- a/src/ophydregistry/registry.py
+++ b/src/ophydregistry/registry.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     _AggregateSignalState = ophydobj.OphydObject
 
+try:
+    from ophyd_async.core import Device as AsyncDevice
+except ImportError:
+    AsyncDevice = ophydobj.OphydObject
+
 from .exceptions import (
     ComponentNotFound,
     InvalidComponentLabel,
@@ -121,7 +126,7 @@ class Registry:
     use_typhos: bool
     keep_references: bool
     _auto_register: bool
-    _valid_classes: Tuple[type] = (ophydobj.OphydObject, _AggregateSignalState)
+    _valid_classes: Tuple[type] = (ophydobj.OphydObject, _AggregateSignalState, AsyncDevice)
 
     # components: Sequence
     _objects_by_name: Mapping


### PR DESCRIPTION
…device as expected.