### PR TITLE
Updated handling of duplicate devices.

### DIFF
--- a/src/ophydregistry/registry.py
+++ b/src/ophydregistry/registry.py
@@ -519,7 +519,7 @@ class Registry:
         return obj
 
     def register(
-        self, component: ophydobj.OphydObject, labels: Optional[Sequence] = None
+            self, component: ophydobj.OphydObject, labels: Optional[Sequence] = None, warn_duplicates=True
     ) -> ophydobj.OphydObject:
         """Register a device, component, etc so that it can be retrieved later.
 
@@ -534,6 +534,9 @@ class Registry:
         labels
           Device labels to use for registration. If `None` (default),
           the devices *_ophyd_labels_* parameter will be used.
+        warn_duplicates
+          If true, a warning will be issued if this device is
+          overwriting a previous device with the same name.
 
         """
         # Determine how to register the device
@@ -552,7 +555,8 @@ class Registry:
             # Ignore any instances with the same name as a previous component
             # (Needed for some sub-components that are just readback
             # values of the parent)
-            # Check that we're not adding a duplicate component name
+            # Check if we're adding a duplicate component name
+            is_duplicate = False
             if name in self._objects_by_name.keys():
                 old_obj = self._objects_by_name[name]
                 is_readback = component in [
@@ -563,11 +567,15 @@ class Registry:
                 if is_readback:
                     msg = f"Ignoring readback with duplicate name: '{name}'"
                     log.debug(msg)
+                    return component
                 else:
                     msg = f"Ignoring component with duplicate name: '{name}'"
-                    log.warning(msg)
-                    warnings.warn(msg)
-                return component
+                    is_duplicate = True
+                    if warn_duplicates:
+                        log.warning(msg)
+                        warnings.warn(msg)
+                    else:
+                        log.debug(msg)
             # Register this component
             log.debug(f"Registering {name}")
             # Create a set for this device name if it doesn't exist
@@ -599,5 +607,5 @@ class Registry:
             else:
                 sub_signals = []
             for cpt_name, cpt in sub_signals:
-                self.register(cpt)
+                self.register(cpt, warn_duplicates=not is_duplicate and warn_duplicates)
         return component

--- a/src/ophydregistry/registry.py
+++ b/src/ophydregistry/registry.py
@@ -519,7 +519,10 @@ class Registry:
         return obj
 
     def register(
-            self, component: ophydobj.OphydObject, labels: Optional[Sequence] = None, warn_duplicates=True
+        self,
+        component: ophydobj.OphydObject,
+        labels: Optional[Sequence] = None,
+        warn_duplicates=True,
     ) -> ophydobj.OphydObject:
         """Register a device, component, etc so that it can be retrieved later.
 

--- a/src/ophydregistry/tests/test_instrument_registry.py
+++ b/src/ophydregistry/tests/test_instrument_registry.py
@@ -6,7 +6,8 @@ from unittest import mock
 
 import pytest
 from ophyd import Device, EpicsMotor, sim
-from ophyd_async.core import Device as AsyncDevice, soft_signal_rw
+from ophyd_async.core import Device as AsyncDevice
+from ophyd_async.core import soft_signal_rw
 
 from ophydregistry import ComponentNotFound, MultipleComponentsFound, Registry
 
@@ -146,11 +147,12 @@ def test_find_component(registry):
 
 def test_find_async_children(registry):
     """Check that the child components of an async device get registered."""
+
     class MyDevice(AsyncDevice):
         def __init__(self, name):
             self.signal = soft_signal_rw()
             super().__init__(name=name)
-        
+
     device = MyDevice(name="m1")
     registry.register(device)
     assert registry.find(device.signal.name) is device.signal
@@ -411,7 +413,7 @@ def test_duplicate_device(caplog, registry):
     # Check that the warning is only issued for the top-level device, not all its children
     assert "motor_user_setpoint" not in caplog.text
     # Check that the correct second device is the one that wound up in the registry
-    assert registry['motor'] is motor2
+    assert registry["motor"] is motor2
 
 
 def test_delete_by_name(registry):


### PR DESCRIPTION
Previously, the old device would be retained and the new device would be ignored. Now, the new device overwrites the old device.

Also, the warning for a duplicate name is only issued for the top level devices in the device hierarchy.

Fixes:
- https://github.com/spc-group/ophyd-registry/issues/10