### PR TITLE
Store devices by name so that duplicate names are allowed.

### DIFF
--- a/src/ophydregistry/tests/test_instrument_registry.py
+++ b/src/ophydregistry/tests/test_instrument_registry.py
@@ -47,32 +47,6 @@ def test_register_component(registry):
     assert cpt in results
 
 
-def test_register_component(registry):
-    # Create an unregistered component
-    cpt = sim.SynGauss(
-        "I0",
-        sim.motor,
-        "motor",
-        center=-0.5,
-        Imax=1,
-        sigma=1,
-        labels={"ion_chamber"},
-    )
-    # Make sure the component doesn't get found without being registered
-    with pytest.raises(ComponentNotFound):
-        list(registry.findall(label="ion_chamber"))
-    with pytest.raises(ComponentNotFound):
-        list(registry.findall(name="I0"))
-    # Now register the component
-    cpt = registry.register(cpt)
-    # Confirm that it's findable by label
-    results = registry.findall(label="ion_chamber")
-    assert cpt in results
-    # Config that it's findable by name
-    results = registry.findall(name="I0")
-    assert cpt in results
-
-
 def test_register_component_with_labels(registry):
     # Create an unregistered component
     cpt = sim.SynGauss(

--- a/src/ophydregistry/tests/test_instrument_registry.py
+++ b/src/ophydregistry/tests/test_instrument_registry.py
@@ -149,7 +149,7 @@ def test_find_async_children(registry):
 
     class MyDevice(AsyncDevice):
         def __init__(self, name):
-            self.signal = soft_signal_rw()
+            self.signal = soft_signal_rw(float)
             super().__init__(name=name)
 
     device = MyDevice(name="m1")


### PR DESCRIPTION
This PR changes the internal mechanics of how devices are stored by name to match the way they are stored by label.

This means that multiple devices with the same name can be registered. Just like with labels, if calling ``Instrument.find()`` and multiple components with the same name are found, a ``MultipleComponentsFound`` exception is raised and it is up to the client code to handle this (or use ``Instrument.findall()``.

To avoid some obvious backwards compatibility issues, ``Instrument.find()`` ignores devices that are children of other devices with the same name.