### PR TITLE
Type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
           ruff check --output-format=github --target-version=py37 --exit-zero src/
       - name: Test with pytest
         run: |
-          pytest src/
+          pytest --mypy src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = ["ophyd"]
 
 [project.optional-dependencies]
 
-dev = ["ophyd_async", "black", "isort", "pytest", "build", "twine", "flake8", "ruff", "pytest-mock", "caproto"]
+dev = ["ophyd_async", "black", "isort", "pytest", "pytest-mypy", "build", "twine", "flake8", "ruff", "pytest-mock", "caproto"]
 
 [project.urls]
 "Homepage" = "https://github.com/spc-group/ophyd-registry"
@@ -31,3 +31,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.isort]
 profile = "black"
+
+[[tool.mypy.overrides]]
+module = ["ophyd.*", "pcdsdevices.*", "typhos.*"]
+ignore_missing_imports = true

--- a/src/ophydregistry/_typing.py
+++ b/src/ophydregistry/_typing.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol, runtime_checkable, Optional, Sequence, Optional, Union
+from typing import Protocol, Sequence, Union, runtime_checkable
 
 
 @runtime_checkable
@@ -11,7 +11,6 @@ class Device(Protocol):
 
         https://blueskyproject.io/event-model/event-descriptors.html#object-keys"""
         ...
-
 
 
 DeviceQuery = Union[str, Device, Sequence[Union[str, Device]]]

--- a/src/ophydregistry/_typing.py
+++ b/src/ophydregistry/_typing.py
@@ -1,0 +1,17 @@
+from abc import abstractmethod
+from typing import Protocol, runtime_checkable, Optional, Sequence, Optional, Union
+
+
+@runtime_checkable
+class Device(Protocol):
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Used to populate object_keys in the Event DataKey
+
+        https://blueskyproject.io/event-model/event-descriptors.html#object-keys"""
+        ...
+
+
+
+DeviceQuery = Union[str, Device, Sequence[Union[str, Device]]]

--- a/src/ophydregistry/registry.py
+++ b/src/ophydregistry/registry.py
@@ -2,27 +2,23 @@ import logging
 import time
 import warnings
 from collections import OrderedDict
+from collections.abc import Iterable
 from itertools import chain
-from typing import Hashable, List, Mapping, Optional, Sequence, Tuple
+from typing import Hashable, List, MutableMapping, Mapping, Optional, Sequence, Tuple, TypeVar
 from weakref import WeakSet, WeakValueDictionary
 
 from ophyd import ophydobj
+from ophydregistry._typing import Device, DeviceQuery
 
-try:
-    from pcdsdevices.signal import _AggregateSignalState
-except ImportError:
-    _AggregateSignalState = ophydobj.OphydObject
-
-try:
-    from ophyd_async.core import Device as AsyncDevice
-except ImportError:
-    AsyncDevice = ophydobj.OphydObject
 
 from .exceptions import (
     ComponentNotFound,
     InvalidComponentLabel,
     MultipleComponentsFound,
 )
+
+
+T = TypeVar("T")
 
 # Sentinal value for default parameters
 UNSET = object()
@@ -43,16 +39,11 @@ __all__ = ["Registry"]
 
 
 def is_iterable(obj):
-    return (not isinstance(obj, str)) and hasattr(obj, "__iter__")
+    return (not isinstance(obj, str)) and isinstance(obj, Iterable)
 
 
-def remove_duplicates(items, key=None):
-    unique_items = list()
-    for item in items:
-        val = item if key is None else key(item)
-        if val not in unique_items:
-            yield item
-            unique_items.append(val)
+def remove_duplicates(items: Sequence[T]) -> list[T]:
+    return list(set(items))
 
 
 def register_typhos_signal(signal):
@@ -130,15 +121,10 @@ class Registry:
     keep_references: bool
     warn_duplicates: bool
     _auto_register: bool
-    _valid_classes: Tuple[type] = (
-        ophydobj.OphydObject,
-        _AggregateSignalState,
-        AsyncDevice,
-    )
 
     # components: Sequence
-    _objects_by_name: Mapping
-    _objects_by_label: Mapping
+    _objects_by_name: MutableMapping
+    _objects_by_label: MutableMapping
 
     def __init__(
         self,
@@ -297,12 +283,12 @@ class Registry:
 
     def find(
         self,
-        any_of: Optional[str] = None,
+        any_of: Optional[DeviceQuery] = None,
         *,
-        label: Optional[str] = None,
-        name: Optional[str] = None,
-        allow_none: Optional[str] = False,
-    ) -> ophydobj.OphydObject:
+        label: Optional[DeviceQuery] = None,
+        name: Optional[DeviceQuery] = None,
+        allow_none: bool = False,
+    ) -> Device | None:
         """Find registered device components matching parameters.
 
         The *any_of* keyword is a proxy for all the other
@@ -366,13 +352,11 @@ class Registry:
         """Is the object already resolved into an ophyd device, etc.
 
         This method checks the type of the object. To extend this to
-        other types of objects, override this objects
-        ``_valid_classes`` attribute with a new set.
+        other types of objects, add the object class to
+        `ophydregistry._typing.Device`.
 
         """
-        if isinstance(obj, self._valid_classes):
-            return True
-        return False
+        return isinstance(obj, Device)
 
     def _findall_by_label(self, label, allow_none):
         # Check for already created ophyd objects (return as is)
@@ -436,12 +420,12 @@ class Registry:
 
     def findall(
         self,
-        any_of: Optional[str] = None,
+        any_of: Optional[DeviceQuery] = None,
         *,
-        label: Optional[str] = None,
-        name: Optional[str] = None,
+        label: Optional[DeviceQuery] = None,
+        name: Optional[DeviceQuery] = None,
         allow_none: Optional[bool] = False,
-    ) -> List[ophydobj.OphydObject]:
+    ) -> List[Device]:
         """Find registered device components matching parameters.
 
         Combining search terms works in an *or* fashion. For example,
@@ -490,7 +474,7 @@ class Registry:
         _name = name if name is not None else any_of
         # Apply several filters against label, name, etc.
         if is_iterable(any_of):
-            for a in any_of:
+            for a in any_of:  # type: ignore  # Device is not iterable, but we checked
                 results.append(self.findall(any_of=a, allow_none=allow_none))
         else:
             # Filter by label
@@ -500,21 +484,12 @@ class Registry:
             if _name is not None:
                 results.append(self._findall_by_name(_name))
         # Peek at the first item to check for an empty result
-        results = chain(*results)
-        try:
-            first = next(results)
-        except StopIteration:
-            # No results were found
-            if allow_none:
-                results = []
-            else:
-                raise ComponentNotFound(
-                    f'Could not find components matching: label="{_label}", name="{_name}"'
-                )
-        else:
-            # Stick the first entry back in the queue and yield it
-            results = chain([first], results)
-        return list(remove_duplicates(results))
+        devices = [device for devices in results for device in devices]
+        if len(devices) == 0 and not allow_none:
+            raise ComponentNotFound(
+                f'Could not find components matching: label="{_label}", name="{_name}"'
+            )
+        return list(remove_duplicates(devices))
 
     def __new__wrapper(self, cls, *args, **kwargs):
         # Create and instantiate the new object
@@ -554,16 +529,12 @@ class Registry:
         # Determine how to register the device
         if isinstance(component, type):
             # A class was given, so instances should be auto-registered
-            component.__new__ = self.__new__wrapper
+            component.__new__ = self.__new__wrapper  # type: ignore
         else:  # An instance was given, so just save it in the register
             try:
                 name = component.name
             except AttributeError:
-                msg = f"Skipping unnamed component {component}"
-                if isinstance(component, _AggregateSignalState):
-                    log.debug(msg)
-                else:
-                    log.info(msg)
+                log.info(f"Skipping unnamed component {component}")
                 return component
             # Register this object with Typhos
             if self.use_typhos:

--- a/src/ophydregistry/registry.py
+++ b/src/ophydregistry/registry.py
@@ -3,20 +3,25 @@ import time
 import warnings
 from collections import OrderedDict
 from collections.abc import Iterable
-from itertools import chain
-from typing import Hashable, List, MutableMapping, Mapping, Optional, Sequence, Tuple, TypeVar
+from typing import (
+    Hashable,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    TypeVar,
+)
 from weakref import WeakSet, WeakValueDictionary
 
 from ophyd import ophydobj
-from ophydregistry._typing import Device, DeviceQuery
 
+from ophydregistry._typing import Device, DeviceQuery
 
 from .exceptions import (
     ComponentNotFound,
     InvalidComponentLabel,
     MultipleComponentsFound,
 )
-
 
 T = TypeVar("T")
 

--- a/src/ophydregistry/tests/test_instrument_registry.py
+++ b/src/ophydregistry/tests/test_instrument_registry.py
@@ -2,7 +2,6 @@ import gc
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
-from unittest import mock
 
 import pytest
 from ophyd import Device, EpicsMotor, sim

--- a/src/ophydregistry/tests/test_instrument_registry.py
+++ b/src/ophydregistry/tests/test_instrument_registry.py
@@ -15,7 +15,6 @@ from ophydregistry import ComponentNotFound, MultipleComponentsFound, Registry
 @pytest.fixture()
 def registry():
     reg = Registry(auto_register=False, use_typhos=False)
-    reg._valid_classes = (mock.MagicMock, *reg._valid_classes)
     try:
         yield reg
     finally:
@@ -150,7 +149,7 @@ def test_find_async_children(registry):
 
     class MyDevice(AsyncDevice):
         def __init__(self, name):
-            self.signal = soft_signal_rw()
+            self.signal = soft_signal_rw(float)
             super().__init__(name=name)
 
     device = MyDevice(name="m1")


### PR DESCRIPTION
Makes ophyd-registry a properly typed package.

One change is that ``Registry.findall()`` now returns a list of devices instead of a chain object.